### PR TITLE
AddressList: fix list addition issue BAL-001

### DIFF
--- a/contracts/AddressList.sol
+++ b/contracts/AddressList.sol
@@ -33,7 +33,7 @@ contract AddressList is AccessControl, IAddressList {
 
     // Anyone: query value associated with address.  returns zero if absent.
     function get(address a) external view override returns (uint256) {
-        return theList.get(a);
+        return theList.contains(a) ? theList.get(a) : 0;
     }
 
     ///////////////////////////////////////////////////////////////
@@ -60,7 +60,7 @@ contract AddressList is AccessControl, IAddressList {
 
     function _add(address a, uint256 v) private returns (bool) {
         require(v != 0);
-        if (theList.get(a) != v) {
+        if (!theList.contains(a) || theList.get(a) != v) {
             theList.set(a, v);
             emit AddressUpdated(a, msg.sender);
             return true;


### PR DESCRIPTION
 BAL-001 Cannot add new entries to an AddressList

Attempting to add an address to a newly created ​AddressList always results in revert. This is because the function ​_add​ has a bug