### PR TITLE
Fixes for avalanche deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@openzeppelin/contracts": "^4.0.0",
     "@openzeppelin/test-helpers": "^0.5.6",
-    "@truffle/hdwallet-provider": "^1.0.36",
+    "@truffle/hdwallet-provider": "^1.4.1",
     "chai": "^4.2.0",
     "dotenv": "^8.2.0",
     "eslint": "^4.18.1",

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -50,7 +50,7 @@ module.exports = {
     },
     avalanche: {
       provider,
-      network_id: 43114,
+      network_id: '*',
       gas: 8000000,
       gasPrice
     },


### PR DESCRIPTION
Update truffle/hdwallet-provider version

Remove network id from avalanche to prevent issue
where truffle incorrectly compares it.